### PR TITLE
Feature/#9 ユーザー入力を保存する

### DIFF
--- a/client/features/playground/constants.ts
+++ b/client/features/playground/constants.ts
@@ -2,11 +2,11 @@ import type { Dispatch, SetStateAction } from 'react';
 import type { Block, BLOCK, SpriteState } from './types';
 
 export const BLOCKS: BLOCK[] = [
-  { id: 1, contents: ['前へ', '$number', '歩進む'] },
-  { id: 2, contents: ['右へ', '$number', '度回る'] },
-  { id: 3, contents: ['左へ', '$number', '度回る'] },
-  { id: 5, contents: ['後ろへ', '$number', '歩戻る'] },
-  { id: 4, contents: ['$number', '秒待つ'] },
+  { id: 1, contents: ['前へ', '$10', '歩進む'] },
+  { id: 2, contents: ['右へ', '$10', '度回る'] },
+  { id: 3, contents: ['左へ', '$10', '度回る'] },
+  { id: 5, contents: ['後ろへ', '$10', '歩戻る'] },
+  { id: 4, contents: ['$10', '秒待つ'] },
 ];
 
 export const BLOCKS_DICT = BLOCKS.reduce(

--- a/client/features/playground/constants.ts
+++ b/client/features/playground/constants.ts
@@ -1,7 +1,7 @@
 import type { Dispatch, SetStateAction } from 'react';
-import type { Block, BLOCK, SpriteState } from './types';
+import type { Block, BLOCK, READONLY_BLOCK, SpriteState } from './types';
 
-export const BLOCKS: BLOCK[] = [
+export const BLOCKS: READONLY_BLOCK[] = [
   { id: 1, contents: ['前へ', '$10', '歩進む'] },
   { id: 2, contents: ['右へ', '$10', '度回る'] },
   { id: 3, contents: ['左へ', '$10', '度回る'] },
@@ -9,13 +9,13 @@ export const BLOCKS: BLOCK[] = [
   { id: 4, contents: ['$10', '秒待つ'] },
 ];
 
-export const BLOCKS_DICT = BLOCKS.reduce(
-  (prev, curr) => {
-    prev[curr.id] = curr;
-    return prev;
-  },
-  {} as Record<number, BLOCK>,
-);
+const emptyBlockDict: Record<number, BLOCK> = {};
+
+export const BLOCKS_DICT = BLOCKS.reduce((prev, curr) => {
+  // @ts-expect-error TS2322
+  prev[curr.id] = curr;
+  return prev;
+}, emptyBlockDict);
 
 export const moves = (
   fn: (arg: Block | string) => void | string | undefined,

--- a/client/features/playground/scriptEditor/ScriptEditor.tsx
+++ b/client/features/playground/scriptEditor/ScriptEditor.tsx
@@ -8,7 +8,8 @@ type ScriptPaletteProps = {
 };
 const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
   const { setTargetBlock: setTargetBlockId } = scriptPaletteProps;
-  const [blocks, setBLOCKS_useState] = useState(BLOCKS);
+  // @ts-expect-error TS2322
+  const [blocks, setBLOCKS_useState] = useState<BLOCK[]>(BLOCKS);
   const ref = useRef<HTMLInputElement>(null);
   const [width, setWidth] = useState(0);
   useEffect(() => {

--- a/client/features/playground/scriptEditor/ScriptEditor.tsx
+++ b/client/features/playground/scriptEditor/ScriptEditor.tsx
@@ -1,13 +1,14 @@
 import type { Dispatch, SetStateAction } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { BLOCKS, BLOCKS_DICT } from '../constants';
-import type { Block } from '../types';
+import type { BLOCK, Block } from '../types';
 import styles from './ScriptEditor.module.css';
 type ScriptPaletteProps = {
-  setTargetBlockId: Dispatch<SetStateAction<number | null>>;
+  setTargetBlock: Dispatch<SetStateAction<BLOCK | null>>;
 };
 const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
-  const { setTargetBlockId } = scriptPaletteProps;
+  const { setTargetBlock: setTargetBlockId } = scriptPaletteProps;
+  const [blocks, setBLOCKS_useState] = useState(BLOCKS);
   const ref = useRef<HTMLInputElement>(null);
   const [width, setWidth] = useState(0);
   useEffect(() => {
@@ -15,18 +16,30 @@ const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
       setWidth(ref.current.offsetWidth);
     }
   });
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>, n: number, i: number) => {
+    const newBLOCKS = structuredClone(blocks);
+    newBLOCKS[n].contents[i] = `$${e.target.value}`;
+
+    setBLOCKS_useState(newBLOCKS);
+  };
   return (
     <div className={styles.scriptPalette}>
-      {BLOCKS.map((block) => (
+      {blocks.map((block, n) => (
         <div
           key={block.id}
           className={styles.block}
           draggable
-          onDragStart={() => setTargetBlockId(block.id)}
+          onDragStart={() => setTargetBlockId(block)}
         >
           {block.contents.map((content, i) =>
             content.startsWith('$') ? (
-              <input className={styles.input} key={i} type="text" value={10} />
+              <input
+                className={styles.input}
+                key={i}
+                type="text"
+                defaultValue={10}
+                onChange={(e) => handleOnChange(e, n, i)}
+              />
             ) : (
               <div key={i}>{content}</div>
             ),
@@ -40,17 +53,23 @@ const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
 type ScriptEditSpaceProps = {
   script: Block[] | undefined;
   setScript: Dispatch<SetStateAction<Block[] | undefined>>;
-  targetBlockId: number | null;
+  targetBlock: BLOCK | null;
 };
 
 const ScriptEditSpace = (scriptEditSpaceProps: ScriptEditSpaceProps) => {
-  const { script, setScript, targetBlockId } = scriptEditSpaceProps;
+  const { script, setScript, targetBlock: targetBlock } = scriptEditSpaceProps;
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
-    if (targetBlockId === null) return;
+    if (targetBlock === null) return;
     const newScript = structuredClone(script ?? []);
-    newScript.push({ id: targetBlockId, arg: ['10'] });
+    console.log(targetBlock);
+    newScript.push({
+      id: targetBlock.id,
+      arg: targetBlock.contents
+        .filter((content) => content.startsWith('$'))
+        .map((content) => content.replace('$', '')),
+    });
     setScript(newScript);
   };
 
@@ -58,13 +77,36 @@ const ScriptEditSpace = (scriptEditSpaceProps: ScriptEditSpaceProps) => {
     event.preventDefault();
   };
 
+  const handleOnChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    n: number,
+    i: number,
+    contents: string[],
+  ) => {
+    const newScript = structuredClone(script ?? []);
+    newScript[n].arg[contents.slice(0, i).filter((content) => content.startsWith('$')).length] =
+      e.target?.value ?? '';
+
+    setScript(newScript);
+  };
+
   return (
     <div className={styles.scriptEditSpace} onDrop={handleDrop} onDragOver={handleDragOver}>
-      {script?.map((block) => (
+      {script?.map((block, n) => (
         <div className={styles.block}>
-          {BLOCKS_DICT[block.id]?.contents.map((content, i) =>
+          {BLOCKS_DICT[block.id]?.contents.map((content, i, contents) =>
             content.startsWith('$') ? (
-              <input className={styles.input} key={i} type="text" value={10} />
+              <input
+                className={styles.input}
+                key={i}
+                type="text"
+                defaultValue={
+                  block.arg[
+                    contents.slice(0, i).filter((content) => content.startsWith('$')).length
+                  ] as string
+                }
+                onChange={(e) => handleOnChange(e, n, i, contents)}
+              />
             ) : (
               <div key={i}>{content}</div>
             ),
@@ -80,12 +122,12 @@ type Props = {
   setScript: Dispatch<SetStateAction<Block[] | undefined>>;
 };
 export const ScriptEditor = (props: Props) => {
-  const [targetBlockId, setTargetBlockId] = useState<number | null>(null);
+  const [targetBlock, setTargetBlockId] = useState<BLOCK | null>(null);
   const { script, setScript } = props;
   return (
     <div className={styles.main}>
-      <ScriptPalette setTargetBlockId={setTargetBlockId} />
-      <ScriptEditSpace script={script} setScript={setScript} targetBlockId={targetBlockId} />
+      <ScriptPalette setTargetBlock={setTargetBlockId} />
+      <ScriptEditSpace script={script} setScript={setScript} targetBlock={targetBlock} />
     </div>
   );
 };

--- a/client/features/playground/scriptEditor/ScriptEditor.tsx
+++ b/client/features/playground/scriptEditor/ScriptEditor.tsx
@@ -7,7 +7,7 @@ type ScriptPaletteProps = {
   setTargetBlock: Dispatch<SetStateAction<BLOCK | null>>;
 };
 const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
-  const { setTargetBlock: setTargetBlockId } = scriptPaletteProps;
+  const { setTargetBlock } = scriptPaletteProps;
   // @ts-expect-error TS2322
   const [blocks, setBLOCKS_useState] = useState<BLOCK[]>(BLOCKS);
   const ref = useRef<HTMLInputElement>(null);
@@ -30,7 +30,7 @@ const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
           key={block.id}
           className={styles.block}
           draggable
-          onDragStart={() => setTargetBlockId(block)}
+          onDragStart={() => setTargetBlock(block)}
         >
           {block.contents.map((content, i) =>
             content.startsWith('$') ? (
@@ -123,11 +123,11 @@ type Props = {
   setScript: Dispatch<SetStateAction<Block[] | undefined>>;
 };
 export const ScriptEditor = (props: Props) => {
-  const [targetBlock, setTargetBlockId] = useState<BLOCK | null>(null);
+  const [targetBlock, setTargetBlock] = useState<BLOCK | null>(null);
   const { script, setScript } = props;
   return (
     <div className={styles.main}>
-      <ScriptPalette setTargetBlock={setTargetBlockId} />
+      <ScriptPalette setTargetBlock={setTargetBlock} />
       <ScriptEditSpace script={script} setScript={setScript} targetBlock={targetBlock} />
     </div>
   );

--- a/client/features/playground/scriptEditor/ScriptEditor.tsx
+++ b/client/features/playground/scriptEditor/ScriptEditor.tsx
@@ -58,13 +58,12 @@ type ScriptEditSpaceProps = {
 };
 
 const ScriptEditSpace = (scriptEditSpaceProps: ScriptEditSpaceProps) => {
-  const { script, setScript, targetBlock: targetBlock } = scriptEditSpaceProps;
+  const { script, setScript, targetBlock } = scriptEditSpaceProps;
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     if (targetBlock === null) return;
     const newScript = structuredClone(script ?? []);
-    console.log(targetBlock);
     newScript.push({
       id: targetBlock.id,
       arg: targetBlock.contents

--- a/client/features/playground/types.ts
+++ b/client/features/playground/types.ts
@@ -1,6 +1,8 @@
 export type Block = { id: number; arg: (Block | string)[] };
 export type BLOCK = { id: number; contents: string[] };
 
+export type READONLY_BLOCK = Readonly<{ [T in keyof BLOCK]: Readonly<BLOCK[T]> }>;
+
 export type SpriteState = {
   x: number;
   y: number;


### PR DESCRIPTION
## ⭐️ 概要
- ユーザー入力を保存するように修正（スプリプトパレット側、スクリプトエディタ側両方において）
- ドラッグされた際に保存するターゲットの情報を変更（idのみ→すべての情報）
- 間違えてconstantsを書き換えないように型を修正

## 😎 目的
Scratchに近づける

## 💬 関連する Issue
close #9