### PR TITLE
Feature/#14 `Preview.tsx`の状態の型や初期値を改善

### DIFF
--- a/client/features/playground/Playground.tsx
+++ b/client/features/playground/Playground.tsx
@@ -5,11 +5,11 @@ import { ScriptEditor } from './scriptEditor/ScriptEditor';
 import type { Block } from './types';
 
 export const Playground = () => {
-  const [script, setScript] = useState<Block[]>();
+  const [scripts, setScripts] = useState<Block[][]>([[]]);
   return (
     <div className={styles.main}>
-      <ScriptEditor script={script} setScript={setScript}></ScriptEditor>
-      <Preview script={script}></Preview>
+      <ScriptEditor scripts={scripts} setScripts={setScripts}></ScriptEditor>
+      <Preview scripts={scripts}></Preview>
     </div>
   );
 };

--- a/client/features/playground/Playground.tsx
+++ b/client/features/playground/Playground.tsx
@@ -9,7 +9,7 @@ export const Playground = () => {
   return (
     <div className={styles.main}>
       <ScriptEditor scripts={scripts} setScripts={setScripts}></ScriptEditor>
-      <Preview scripts={scripts}></Preview>
+      <Preview scripts={scripts} key={JSON.stringify(scripts)}></Preview>
     </div>
   );
 };

--- a/client/features/playground/constants.ts
+++ b/client/features/playground/constants.ts
@@ -21,7 +21,7 @@ export const moves = (
   fn: (arg: Block | string) => void | string | undefined,
   args: (Block | string)[],
   setState: Dispatch<SetStateAction<SpriteState>>,
-  setStepDelay: Dispatch<SetStateAction<number | null>>,
+  setStepDelay: (newDelay: number | null) => void,
 ): Record<number, () => void> => {
   const arg = (n: number) => fn(args[n]);
   setStepDelay(null);

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -73,11 +73,7 @@ export const Preview = (props: Props) => {
 
   const intervalId = ({ script, active, stepDelay, stepCount }: ScriptState, i: number) => {
     if (active && isStart) {
-      const intervalId = setInterval(
-        () => interval(i, script, stepCount),
-        (stepDelay ?? stepSpeed) * 1000,
-      );
-      return intervalId;
+      return setInterval(() => interval(i, script, stepCount), (stepDelay ?? stepSpeed) * 1000);
     }
     return undefined;
   };

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -15,19 +15,18 @@ type ScriptState = {
   stepCount: number;
 };
 
-const createScriptState = (scripts: Block[][]) =>
-  scripts?.map((script) => ({
-    script,
-    active: true,
-    stepDelay: 0,
-    stepCount: 0,
-  }));
-
 export const Preview = (props: Props) => {
   const { scripts } = props;
   const [stepSpeed, setStepSpeed] = useState(1);
   const [isStart, setIsStart] = useState(false);
-  const [scriptStates, setScriptStates] = useState<ScriptState[]>(createScriptState(scripts));
+  const [scriptStates, setScriptStates] = useState<ScriptState[]>(
+    scripts?.map((script) => ({
+      script,
+      active: true,
+      stepDelay: 0,
+      stepCount: 0,
+    })),
+  );
   const [state, setState] = useState<SpriteState>({
     x: 0,
     y: 0,

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -35,10 +35,6 @@ export const Preview = (props: Props) => {
   });
 
   useEffect(() => {
-    setScriptStates(createScriptState(scripts));
-  }, [scripts]);
-
-  useEffect(() => {
     const newScriptStates = structuredClone(scriptStates);
     const intervalIds = scriptStates.map(({ script, active, stepDelay, stepCount }, i) => {
       if (active && isStart) {

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -40,7 +40,7 @@ export const Preview = (props: Props) => {
       if (active && isStart) {
         const intervalId = setInterval(
           () => {
-            if (stepCount >= (script.length ?? 0)) {
+            if (stepCount >= script.length) {
               newScriptStates[i].active = false;
               newScriptStates[i].stepCount = 0;
               newScriptStates[i].stepDelay = 0;

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -5,48 +5,81 @@ import type { Block, SpriteState } from '../types';
 import styles from './Preview.module.css';
 
 type Props = {
-  script: Block[] | undefined;
+  scripts: Block[][];
 };
 
+type ScriptState = {
+  script: Block[];
+  active: boolean;
+  stepDelay: number | null;
+  stepCount: number;
+};
+
+const createScriptState = (scripts: Block[][]) =>
+  scripts?.map((script) => ({
+    script,
+    active: true,
+    stepDelay: 0,
+    stepCount: 0,
+  }));
+
 export const Preview = (props: Props) => {
-  const [stepCounts, setStepCounts] = useState([0]);
+  const { scripts } = props;
   const [stepSpeed, setStepSpeed] = useState(1);
-  const [stepDelay, setStepDelay] = useState<number | null>(null);
   const [isStart, setIsStart] = useState(false);
+  const [scriptStates, setScriptStates] = useState<ScriptState[]>(createScriptState(scripts));
   const [state, setState] = useState<SpriteState>({
     x: 0,
     y: 0,
     direction: 0,
   });
-  const { script } = props;
+
   useEffect(() => {
-    if (isStart) {
-      const intervalId = setInterval(
-        () => {
-          if (stepCounts[0] >= (script?.length ?? 0)) {
-            setIsStart(false);
-            setStepCounts([0]);
-            clearInterval(intervalId);
-            return;
-          }
-          const block = script?.[stepCounts[0]];
-          if (block === undefined) return;
+    setScriptStates(createScriptState(scripts));
+  }, [scripts]);
 
-          const step = (block: Block | string): void | string | undefined => {
-            if (typeof block === 'string') {
-              return block;
+  useEffect(() => {
+    const newScriptStates = structuredClone(scriptStates);
+    const intervalIds = scriptStates.map(({ script, active, stepDelay, stepCount }, i) => {
+      if (active && isStart) {
+        const intervalId = setInterval(
+          () => {
+            if (stepCount >= (script.length ?? 0)) {
+              newScriptStates[i].active = false;
+              newScriptStates[i].stepCount = 0;
+              newScriptStates[i].stepDelay = 0;
+              setScriptStates([...newScriptStates]);
+              return;
             }
+            const block = script?.[stepCount];
+            if (block === undefined) return;
 
-            return moves(step, block.arg, setState, setStepDelay)[block.id]?.();
-          };
-          step(block);
-          setStepCounts((prev) => [prev[0] + 1]);
-        },
-        (stepDelay ?? stepSpeed) * 1000,
-      );
-      return () => clearInterval(intervalId);
-    }
-  }, [script, stepCounts, isStart]);
+            const step = (block: Block | string): void | string | undefined => {
+              if (typeof block === 'string') {
+                return block;
+              }
+              const setStepDelay = (newDelay: number | null) => {
+                newScriptStates[i].stepDelay = newDelay;
+              };
+
+              return moves(step, block.arg, setState, setStepDelay)[block.id]?.();
+            };
+            newScriptStates[i].stepCount += 1;
+            newScriptStates[i].stepDelay = null;
+            step(block);
+            setScriptStates([...newScriptStates]);
+          },
+          (stepDelay ?? stepSpeed) * 1000,
+        );
+        return intervalId;
+      }
+      return undefined;
+    });
+    return () => {
+      intervalIds?.forEach((intervalId) => clearInterval(intervalId));
+    };
+  }, [scriptStates, isStart, stepSpeed]);
+
   return (
     <div className={styles.main}>
       <AlignBox x={'|..'}>

--- a/client/features/playground/scriptEditor/ScriptEditor.tsx
+++ b/client/features/playground/scriptEditor/ScriptEditor.tsx
@@ -1,133 +1,21 @@
 import type { Dispatch, SetStateAction } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
-import { BLOCKS, BLOCKS_DICT } from '../constants';
+import { useState } from 'react';
 import type { BLOCK, Block } from '../types';
 import styles from './ScriptEditor.module.css';
-type ScriptPaletteProps = {
-  setTargetBlock: Dispatch<SetStateAction<BLOCK | null>>;
-};
-const ScriptPalette = (scriptPaletteProps: ScriptPaletteProps) => {
-  const { setTargetBlock } = scriptPaletteProps;
-  // @ts-expect-error TS2322
-  const [blocks, setBLOCKS_useState] = useState<BLOCK[]>(BLOCKS);
-  const ref = useRef<HTMLInputElement>(null);
-  const [width, setWidth] = useState(0);
-  useEffect(() => {
-    if (ref.current) {
-      setWidth(ref.current.offsetWidth);
-    }
-  });
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>, n: number, i: number) => {
-    const newBLOCKS = structuredClone(blocks);
-    newBLOCKS[n].contents[i] = `$${e.target.value}`;
-
-    setBLOCKS_useState(newBLOCKS);
-  };
-  return (
-    <div className={styles.scriptPalette}>
-      {blocks.map((block, n) => (
-        <div
-          key={block.id}
-          className={styles.block}
-          draggable
-          onDragStart={() => setTargetBlock(block)}
-        >
-          {block.contents.map((content, i) =>
-            content.startsWith('$') ? (
-              <input
-                className={styles.input}
-                key={i}
-                type="text"
-                defaultValue={10}
-                onChange={(e) => handleOnChange(e, n, i)}
-              />
-            ) : (
-              <div key={i}>{content}</div>
-            ),
-          )}
-        </div>
-      ))}
-    </div>
-  );
-};
-
-type ScriptEditSpaceProps = {
-  script: Block[] | undefined;
-  setScript: Dispatch<SetStateAction<Block[] | undefined>>;
-  targetBlock: BLOCK | null;
-};
-
-const ScriptEditSpace = (scriptEditSpaceProps: ScriptEditSpaceProps) => {
-  const { script, setScript, targetBlock } = scriptEditSpaceProps;
-
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    if (targetBlock === null) return;
-    const newScript = structuredClone(script ?? []);
-    newScript.push({
-      id: targetBlock.id,
-      arg: targetBlock.contents
-        .filter((content) => content.startsWith('$'))
-        .map((content) => content.replace('$', '')),
-    });
-    setScript(newScript);
-  };
-
-  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-  };
-
-  const handleOnChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-    n: number,
-    i: number,
-    contents: string[],
-  ) => {
-    const newScript = structuredClone(script ?? []);
-    newScript[n].arg[contents.slice(0, i).filter((content) => content.startsWith('$')).length] =
-      e.target?.value ?? '';
-
-    setScript(newScript);
-  };
-
-  return (
-    <div className={styles.scriptEditSpace} onDrop={handleDrop} onDragOver={handleDragOver}>
-      {script?.map((block, n) => (
-        <div className={styles.block}>
-          {BLOCKS_DICT[block.id]?.contents.map((content, i, contents) =>
-            content.startsWith('$') ? (
-              <input
-                className={styles.input}
-                key={i}
-                type="text"
-                defaultValue={
-                  block.arg[
-                    contents.slice(0, i).filter((content) => content.startsWith('$')).length
-                  ] as string
-                }
-                onChange={(e) => handleOnChange(e, n, i, contents)}
-              />
-            ) : (
-              <div key={i}>{content}</div>
-            ),
-          )}
-        </div>
-      ))}
-    </div>
-  );
-};
+import { ScriptEditSpace } from './scriptEditSpace/ScriptEditSpace';
+import { ScriptPalette } from './scriptPalette/ScriptPalette';
 
 type Props = {
-  script: Block[] | undefined;
-  setScript: Dispatch<SetStateAction<Block[] | undefined>>;
+  scripts: Block[][];
+  setScripts: Dispatch<SetStateAction<Block[][]>>;
 };
 export const ScriptEditor = (props: Props) => {
   const [targetBlock, setTargetBlock] = useState<BLOCK | null>(null);
-  const { script, setScript } = props;
+  const { scripts, setScripts } = props;
   return (
     <div className={styles.main}>
       <ScriptPalette setTargetBlock={setTargetBlock} />
-      <ScriptEditSpace script={script} setScript={setScript} targetBlock={targetBlock} />
+      <ScriptEditSpace scripts={scripts} setScripts={setScripts} targetBlock={targetBlock} />
     </div>
   );
 };

--- a/client/features/playground/scriptEditor/scriptEditSpace/ScriptEditSpace.tsx
+++ b/client/features/playground/scriptEditor/scriptEditSpace/ScriptEditSpace.tsx
@@ -1,0 +1,141 @@
+import { BLOCKS_DICT } from 'features/playground/constants';
+import type { Block, BLOCK } from 'features/playground/types';
+import type { Dispatch, SetStateAction } from 'react';
+import React from 'react';
+import styles from '../ScriptEditor.module.css';
+
+const updateScriptValue = (arg: Block | string, script: Block, indexes: number[]) => {
+  const index = indexes.shift();
+  if (index === undefined) {
+    throw new Error('Invalid index');
+  }
+  if (indexes.length > 0) {
+    if (typeof script.arg[index] === 'string') {
+      throw new Error('Invalid indexes');
+    }
+    updateScriptValue(arg, script.arg[index], indexes);
+    return;
+  }
+  script.arg[index] = arg ?? '';
+};
+
+type ScriptBlockProps = {
+  block: Block;
+  n: number;
+  indexes: number[];
+  handleOnChange: (e: React.ChangeEvent<HTMLInputElement>, n: number, is: number[]) => void;
+  handleDrop: (e: React.DragEvent<HTMLInputElement>, n: number, is: number[]) => void;
+};
+
+const ScriptBlock = (props: ScriptBlockProps) => {
+  const { block, n, indexes, handleOnChange, handleDrop } = props;
+  return (
+    <>
+      {BLOCKS_DICT[block.id]?.contents.map((content, i, contents) => {
+        if (content.startsWith('$')) {
+          const argIndex = contents.slice(0, i).filter((content) => content.startsWith('$')).length;
+          const newIndexes = [...indexes, argIndex];
+          const arg = block.arg[argIndex];
+          if (typeof arg === 'string') {
+            return (
+              <input
+                className={styles.input}
+                key={i}
+                type="text"
+                defaultValue={arg}
+                onChange={(e) => handleOnChange(e, n, newIndexes)}
+                onDrop={(e) => handleDrop(e, n, newIndexes)}
+              />
+            );
+          }
+          return (
+            <ScriptBlock
+              key={i}
+              block={arg}
+              n={n}
+              indexes={newIndexes}
+              handleOnChange={handleOnChange}
+              handleDrop={handleDrop}
+            />
+          );
+        }
+        return <div key={i}>{content}</div>;
+      })}
+    </>
+  );
+};
+
+type Props = {
+  scripts: Block[][];
+  setScripts: Dispatch<SetStateAction<Block[][]>>;
+  targetBlock: BLOCK | null;
+};
+
+export const ScriptEditSpace = (scriptEditSpaceProps: Props) => {
+  const { scripts, setScripts, targetBlock } = scriptEditSpaceProps;
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (targetBlock === null) return;
+    const newScripts = structuredClone(scripts);
+    newScripts[0].push({
+      id: targetBlock.id,
+      arg: targetBlock.contents
+        .filter((content) => content.startsWith('$'))
+        .map((content) => content.replace('$', '')),
+    });
+    setScripts(newScripts);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>, n: number, indexes: number[]) => {
+    const newScripts = structuredClone(scripts);
+
+    updateScriptValue(e.target.value, newScripts[0][n], indexes);
+    setScripts(newScripts);
+  };
+
+  const handleDropToInput = (
+    e: React.DragEvent<HTMLInputElement>,
+    n: number,
+    indexes: number[],
+  ) => {
+    if (targetBlock === null) return;
+    const newScripts = structuredClone(scripts);
+    updateScriptValue(
+      {
+        id: targetBlock.id,
+        arg: targetBlock.contents
+          .filter((content) => content.startsWith('$'))
+          .map((content) => content.replace('$', '')),
+      },
+      newScripts[0][n],
+      indexes,
+    );
+    setScripts(newScripts);
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return (
+    <div className={styles.scriptEditSpace} onDrop={handleDrop} onDragOver={handleDragOver}>
+      {scripts.map((script) =>
+        script.map((block, n) => (
+          <div className={styles.block} key={n}>
+            <ScriptBlock
+              key={n}
+              block={block}
+              n={n}
+              indexes={[]}
+              handleOnChange={handleOnChange}
+              handleDrop={handleDropToInput}
+            />
+          </div>
+        )),
+      )}
+    </div>
+  );
+};

--- a/client/features/playground/scriptEditor/scriptPalette/ScriptPalette.tsx
+++ b/client/features/playground/scriptEditor/scriptPalette/ScriptPalette.tsx
@@ -1,0 +1,54 @@
+import { BLOCKS } from 'features/playground/constants';
+import type { BLOCK } from 'features/playground/types';
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import styles from '../ScriptEditor.module.css';
+
+type Props = {
+  setTargetBlock: Dispatch<SetStateAction<BLOCK | null>>;
+};
+
+export const ScriptPalette = (scriptPaletteProps: Props) => {
+  const { setTargetBlock } = scriptPaletteProps;
+  // @ts-expect-error TS2322
+  const [blocks, setBLOCKS_useState] = useState<BLOCK[]>(BLOCKS);
+  const ref = useRef<HTMLInputElement>(null);
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    if (ref.current) {
+      setWidth(ref.current.offsetWidth);
+    }
+  });
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>, n: number, i: number) => {
+    const newBLOCKS = structuredClone(blocks);
+    newBLOCKS[n].contents[i] = `$${e.target.value}`;
+
+    setBLOCKS_useState(newBLOCKS);
+  };
+  return (
+    <div className={styles.scriptPalette}>
+      {blocks.map((block, n) => (
+        <div
+          key={block.id}
+          className={styles.block}
+          draggable
+          onDragStart={() => setTargetBlock(block)}
+        >
+          {block.contents.map((content, i) =>
+            content.startsWith('$') ? (
+              <input
+                className={styles.input}
+                key={i}
+                type="text"
+                defaultValue={10}
+                onChange={(e) => handleOnChange(e, n, i)}
+              />
+            ) : (
+              <div key={i}>{content}</div>
+            ),
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## ⭐️ 概要

- おおもとの状態を`script`から`scripts`へと、配列化した
- それに対応するため`Preview.tsx`を大幅に変更
- 各`script`ごとに実行状態を持てるようにpropsの値をmapして初期化
- ネストが深くなったので関数分割した

## 😎 目的

様々な機能を追加する前に、複数のスクリプトの根がある場合の対処をしておくことで後から対応するより変更量が減ってマシになりそうな気がする

## 💬 関連する Issue
close #14