### PR TITLE
Feature/#29 ネストしたスクリプトの動きの制御周りの修正およびリファクタリング

### DIFF
--- a/client/features/playground/Playground.tsx
+++ b/client/features/playground/Playground.tsx
@@ -5,40 +5,7 @@ import { ScriptEditor } from './scriptEditor/ScriptEditor';
 import type { Block } from './types';
 
 export const Playground = () => {
-  const [scripts, setScripts] = useState<Block[][]>([
-    [
-      { id: 0, arg: [] },
-      {
-        id: 8,
-        arg: [
-          'true',
-          [
-            {
-              id: 6,
-              arg: [
-                'false',
-                [
-                  { id: 1, arg: ['10'] },
-                  { id: 1, arg: ['10'] },
-                ],
-              ],
-            },
-            {
-              id: 6,
-              arg: [
-                'true',
-                [
-                  { id: 1, arg: ['10'] },
-                  { id: 1, arg: ['10'] },
-                ],
-              ],
-            },
-          ],
-        ],
-      },
-      { id: 1, arg: ['10'] },
-    ],
-  ]);
+  const [scripts, setScripts] = useState<Block[][]>([[]]);
   return (
     <div className={styles.main}>
       <ScriptEditor scripts={scripts} setScripts={setScripts}></ScriptEditor>

--- a/client/features/playground/Playground.tsx
+++ b/client/features/playground/Playground.tsx
@@ -5,7 +5,40 @@ import { ScriptEditor } from './scriptEditor/ScriptEditor';
 import type { Block } from './types';
 
 export const Playground = () => {
-  const [scripts, setScripts] = useState<Block[][]>([[]]);
+  const [scripts, setScripts] = useState<Block[][]>([
+    [
+      { id: 0, arg: [] },
+      {
+        id: 8,
+        arg: [
+          'true',
+          [
+            {
+              id: 6,
+              arg: [
+                'false',
+                [
+                  { id: 1, arg: ['10'] },
+                  { id: 1, arg: ['10'] },
+                ],
+              ],
+            },
+            {
+              id: 6,
+              arg: [
+                'true',
+                [
+                  { id: 1, arg: ['10'] },
+                  { id: 1, arg: ['10'] },
+                ],
+              ],
+            },
+          ],
+        ],
+      },
+      { id: 1, arg: ['10'] },
+    ],
+  ]);
   return (
     <div className={styles.main}>
       <ScriptEditor scripts={scripts} setScripts={setScripts}></ScriptEditor>

--- a/client/features/playground/constants.ts
+++ b/client/features/playground/constants.ts
@@ -1,7 +1,12 @@
 import type { Dispatch, SetStateAction } from 'react';
 import type { BLOCK, blockArg, READONLY_BLOCK, ScriptState, SpriteState } from './types';
 import { nestedStepMoveBase } from './utils/nestedStepMoveBase';
-import { scriptStatesHandler } from './utils/scriptStatesHandler';
+import {
+  addLoopCount,
+  resetStepCount,
+  setStepDelay,
+  updateNestedStatus,
+} from './utils/scriptStatesHandler';
 
 export const BLOCKS: READONLY_BLOCK[] = [
   { id: 0, contents: ['もし▶ボタンが押されたなら'] },
@@ -30,7 +35,6 @@ export const moves = (
   nestCount: number,
   setState: Dispatch<SetStateAction<SpriteState>>,
 ): Record<number, () => void> => {
-  const { setStepDelay, resetStepCount, addLoopCount, updateNestedStatus } = scriptStatesHandler;
   const arg = (n: number) => fn(args[n]);
   setStepDelay(scriptState, null);
   return {

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -8,19 +8,19 @@ type Props = {
   scripts: Block[][];
 };
 
+const defaultScriptState = (script: Block[]) => ({
+  script,
+  active: false,
+  stepDelay: 0,
+  stepCount: [0],
+  loopCount: [0],
+  nestStatus: [true],
+});
+
 export const Preview = (props: Props) => {
   const { scripts } = props;
   const [stepSpeed, setStepSpeed] = useState(1);
-  const [scriptStates, setScriptStates] = useState<ScriptState[]>(
-    scripts?.map((script) => ({
-      script,
-      active: false,
-      stepDelay: 0,
-      stepCount: [0],
-      loopCount: [0],
-      nestStatus: [true],
-    })),
-  );
+  const [scriptStates, setScriptStates] = useState<ScriptState[]>(scripts?.map(defaultScriptState));
   const [state, setState] = useState<SpriteState>({
     x: 0,
     y: 0,
@@ -36,9 +36,7 @@ export const Preview = (props: Props) => {
   const interval = (i: number, script: Block[], stepCount: number[]) => {
     if (stepCount[0] >= script.length) {
       updateScriptState((scriptStates) => {
-        scriptStates[i].active = false;
-        scriptStates[i].stepCount = [0];
-        scriptStates[i].stepDelay = 0;
+        scriptStates[i] = defaultScriptState(scriptStates[i].script);
       });
       return;
     }
@@ -52,13 +50,7 @@ export const Preview = (props: Props) => {
           return block;
         }
         if (block instanceof Array) return;
-        return moves(
-          step,
-          block.arg,
-          scriptStates[i],
-          0,
-          setState,
-        )[block.id]?.();
+        return moves(step, block.arg, scriptStates[i], 0, setState)[block.id]?.();
       };
       step(block);
       scriptStates[i].stepCount[scriptStates[i].stepCount.length - 1] += 1;
@@ -83,14 +75,7 @@ export const Preview = (props: Props) => {
     setScriptStates(
       scriptStates
         .filter(({ script }) => script[0]?.id === 0)
-        .map(({ script, active, stepDelay, stepCount, loopCount, nestStatus }) => ({
-          script,
-          active: !active,
-          stepDelay,
-          stepCount,
-          loopCount,
-          nestStatus,
-        })),
+        .map((scriptState) => ({ ...scriptState, active: !scriptState.active, stepDelay: 0 })),
     );
   };
   return (

--- a/client/features/playground/preview/Preview.tsx
+++ b/client/features/playground/preview/Preview.tsx
@@ -48,45 +48,6 @@ export const Preview = (props: Props) => {
     if (block === undefined) return;
     updateScriptState((scriptStates) => {
       const step = (block: blockArg): void | string | undefined => {
-        const setStepDelay = (newDelay: number | null) => {
-          scriptStates[i].stepDelay = newDelay;
-        };
-        const addNestToStepCount = (nestCount: number) => {
-          if (scriptStates[i].stepCount.length > nestCount) {
-            return;
-          }
-          scriptStates[i].stepCount.push(0);
-        };
-        const deleteNestFromStepCount = () => {
-          scriptStates[i].stepCount.pop();
-        };
-        const resetStepCount = () => {
-          scriptStates[i].stepCount[scriptStates[i].stepCount.length - 1] = -1;
-        };
-        const addNestToLoopCount = (nestCount: number) => {
-          if (scriptStates[i].loopCount.length > nestCount) {
-            return;
-          }
-          scriptStates[i].loopCount.push(0);
-        };
-        const deleteNestFromLoopCount = () => {
-          scriptStates[i].loopCount.pop();
-        };
-        const addLoopCount = () => {
-          scriptStates[i].loopCount[scriptStates[i].loopCount.length - 1] += 1;
-        };
-        const addNestToStatus = (nestCount: number, status: boolean) => {
-          if (scriptStates[i].nestStatus.length > nestCount) {
-            return;
-          }
-          scriptStates[i].nestStatus.push(status);
-        };
-        const deleteNestFromNestStatus = () => {
-          scriptStates[i].nestStatus.pop();
-        };
-        const updateNestedStatus = (nestCount: number, status: boolean) => {
-          scriptStates[i].nestStatus[scriptStates[i].nestStatus.length - 1] = status;
-        };
         if (typeof block === 'string') {
           return block;
         }
@@ -97,16 +58,6 @@ export const Preview = (props: Props) => {
           scriptStates[i],
           0,
           setState,
-          setStepDelay,
-          addNestToStepCount,
-          resetStepCount,
-          deleteNestFromStepCount,
-          addNestToLoopCount,
-          deleteNestFromLoopCount,
-          addLoopCount,
-          addNestToStatus,
-          deleteNestFromNestStatus,
-          updateNestedStatus,
         )[block.id]?.();
       };
       step(block);

--- a/client/features/playground/utils/nestedStepMoveBase.ts
+++ b/client/features/playground/utils/nestedStepMoveBase.ts
@@ -1,7 +1,15 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { moves } from '../constants';
 import type { Block, blockArg, ScriptState, SpriteState } from '../types';
-import { scriptStatesHandler } from './scriptStatesHandler';
+import {
+  addNestToLoopCount,
+  addNestToStatus,
+  addNestToStepCount,
+  deleteNestFromLoopCount,
+  deleteNestFromNestStatus,
+  deleteNestFromStepCount,
+  setStepDelay,
+} from './scriptStatesHandler';
 
 export const nestedStepMoveBase = (
   fn: (arg: blockArg) => void | string | undefined,
@@ -13,16 +21,6 @@ export const nestedStepMoveBase = (
   setState: Dispatch<SetStateAction<SpriteState>>,
   afterFn?: () => void,
 ) => {
-  const {
-    setStepDelay,
-    addNestToStepCount,
-    deleteNestFromStepCount,
-    addNestToLoopCount,
-    deleteNestFromLoopCount,
-    addNestToStatus,
-    deleteNestFromNestStatus,
-  } = scriptStatesHandler;
-
   if (scriptState.nestStatus.length <= nestCount) {
     addNestToStepCount(scriptState);
     addNestToLoopCount(scriptState);

--- a/client/features/playground/utils/scriptStatesHandler.ts
+++ b/client/features/playground/utils/scriptStatesHandler.ts
@@ -1,34 +1,36 @@
 import type { ScriptState } from '../types';
 
-export const scriptStatesHandler = {
-  setStepDelay: (scriptState: ScriptState, newDelay: number | null) => {
-    scriptState.stepDelay = newDelay;
-  },
-  addNestToStepCount: (scriptState: ScriptState) => {
-    scriptState.stepCount.push(0);
-  },
-  deleteNestFromStepCount: (scriptState: ScriptState) => {
-    scriptState.stepCount.pop();
-  },
-  resetStepCount: (scriptState: ScriptState, nestCount: number) => {
-    scriptState.stepCount[nestCount] = -1;
-  },
-  addNestToLoopCount: (scriptState: ScriptState) => {
-    scriptState.loopCount.push(0);
-  },
-  deleteNestFromLoopCount: (scriptState: ScriptState) => {
-    scriptState.loopCount.pop();
-  },
-  addLoopCount: (scriptState: ScriptState, nestCount: number) => {
-    scriptState.loopCount[nestCount] += 1;
-  },
-  addNestToStatus: (scriptState: ScriptState, status: boolean) => {
-    scriptState.nestStatus.push(status);
-  },
-  deleteNestFromNestStatus: (scriptState: ScriptState) => {
-    scriptState.nestStatus.pop();
-  },
-  updateNestedStatus: (scriptState: ScriptState, nestCount: number, status: boolean) => {
-    scriptState.nestStatus[nestCount] = status;
-  },
+export const setStepDelay = (scriptState: ScriptState, newDelay: number | null) => {
+  scriptState.stepDelay = newDelay;
+};
+export const addNestToStepCount = (scriptState: ScriptState) => {
+  scriptState.stepCount.push(0);
+};
+export const deleteNestFromStepCount = (scriptState: ScriptState) => {
+  scriptState.stepCount.pop();
+};
+export const resetStepCount = (scriptState: ScriptState, nestCount: number) => {
+  scriptState.stepCount[nestCount] = -1;
+};
+export const addNestToLoopCount = (scriptState: ScriptState) => {
+  scriptState.loopCount.push(0);
+};
+export const deleteNestFromLoopCount = (scriptState: ScriptState) => {
+  scriptState.loopCount.pop();
+};
+export const addLoopCount = (scriptState: ScriptState, nestCount: number) => {
+  scriptState.loopCount[nestCount] += 1;
+};
+export const addNestToStatus = (scriptState: ScriptState, status: boolean) => {
+  scriptState.nestStatus.push(status);
+};
+export const deleteNestFromNestStatus = (scriptState: ScriptState) => {
+  scriptState.nestStatus.pop();
+};
+export const updateNestedStatus = (
+  scriptState: ScriptState,
+  nestCount: number,
+  status: boolean,
+) => {
+  scriptState.nestStatus[nestCount] = status;
 };

--- a/client/features/playground/utils/scriptStatesHandler.ts
+++ b/client/features/playground/utils/scriptStatesHandler.ts
@@ -1,0 +1,43 @@
+import type { ScriptState } from '../types';
+
+export const scriptStatesHandler = {
+  setStepDelay: (scriptState: ScriptState, newDelay: number | null) => {
+    scriptState.stepDelay = newDelay;
+  },
+  addNestToStepCount: (scriptState: ScriptState, nestCount: number) => {
+    if (scriptState.stepCount.length > nestCount) {
+      return;
+    }
+    scriptState.stepCount.push(0);
+  },
+  deleteNestFromStepCount: (scriptState: ScriptState) => {
+    scriptState.stepCount.pop();
+  },
+  resetStepCount: (scriptState: ScriptState) => {
+    scriptState.stepCount[scriptState.stepCount.length - 1] = -1;
+  },
+  addNestToLoopCount: (scriptState: ScriptState, nestCount: number) => {
+    if (scriptState.loopCount.length > nestCount) {
+      return;
+    }
+    scriptState.loopCount.push(0);
+  },
+  deleteNestFromLoopCount: (scriptState: ScriptState) => {
+    scriptState.loopCount.pop();
+  },
+  addLoopCount: (scriptState: ScriptState) => {
+    scriptState.loopCount[scriptState.loopCount.length - 1] += 1;
+  },
+  addNestToStatus: (scriptState: ScriptState, nestCount: number, status: boolean) => {
+    if (scriptState.nestStatus.length > nestCount) {
+      return;
+    }
+    scriptState.nestStatus.push(status);
+  },
+  deleteNestFromNestStatus: (scriptState: ScriptState) => {
+    scriptState.nestStatus.pop();
+  },
+  updateNestedStatus: (scriptState: ScriptState, nestCount: number, status: boolean) => {
+    scriptState.nestStatus[scriptState.nestStatus.length - 1] = status;
+  },
+};

--- a/client/features/playground/utils/scriptStatesHandler.ts
+++ b/client/features/playground/utils/scriptStatesHandler.ts
@@ -4,40 +4,31 @@ export const scriptStatesHandler = {
   setStepDelay: (scriptState: ScriptState, newDelay: number | null) => {
     scriptState.stepDelay = newDelay;
   },
-  addNestToStepCount: (scriptState: ScriptState, nestCount: number) => {
-    if (scriptState.stepCount.length > nestCount) {
-      return;
-    }
+  addNestToStepCount: (scriptState: ScriptState) => {
     scriptState.stepCount.push(0);
   },
   deleteNestFromStepCount: (scriptState: ScriptState) => {
     scriptState.stepCount.pop();
   },
-  resetStepCount: (scriptState: ScriptState) => {
-    scriptState.stepCount[scriptState.stepCount.length - 1] = -1;
+  resetStepCount: (scriptState: ScriptState, nestCount: number) => {
+    scriptState.stepCount[nestCount] = -1;
   },
-  addNestToLoopCount: (scriptState: ScriptState, nestCount: number) => {
-    if (scriptState.loopCount.length > nestCount) {
-      return;
-    }
+  addNestToLoopCount: (scriptState: ScriptState) => {
     scriptState.loopCount.push(0);
   },
   deleteNestFromLoopCount: (scriptState: ScriptState) => {
     scriptState.loopCount.pop();
   },
-  addLoopCount: (scriptState: ScriptState) => {
-    scriptState.loopCount[scriptState.loopCount.length - 1] += 1;
+  addLoopCount: (scriptState: ScriptState, nestCount: number) => {
+    scriptState.loopCount[nestCount] += 1;
   },
-  addNestToStatus: (scriptState: ScriptState, nestCount: number, status: boolean) => {
-    if (scriptState.nestStatus.length > nestCount) {
-      return;
-    }
+  addNestToStatus: (scriptState: ScriptState, status: boolean) => {
     scriptState.nestStatus.push(status);
   },
   deleteNestFromNestStatus: (scriptState: ScriptState) => {
     scriptState.nestStatus.pop();
   },
   updateNestedStatus: (scriptState: ScriptState, nestCount: number, status: boolean) => {
-    scriptState.nestStatus[scriptState.nestStatus.length - 1] = status;
+    scriptState.nestStatus[nestCount] = status;
   },
 };


### PR DESCRIPTION
## ⭐️ 概要


- `if`,`for`,`while`の共通する部分を`nestedStepMoveBase`に切り出した
- `scriptStates`を変更する関数群を`Preview`で定義して引数に渡すのをやめて`scriptStatesHandler`に切り出した
- `defaulteSctiptState`を定義することで初期化時とリセット時に同じことを二回書いていたのを解消
- 一時停止時のコードをスプレッド構文を使い簡略化

## 😎 目的

コードを理解しやすくなる


## 💬 関連する Issue

close #29 

