### PR TITLE
add: dropOnPrevElement　忘れていたコミットを追加

### DIFF
--- a/client/features/playground/scriptEditor/scriptEditSpace/ScriptEditSpace.tsx
+++ b/client/features/playground/scriptEditor/scriptEditSpace/ScriptEditSpace.tsx
@@ -119,7 +119,12 @@ const ScriptBlock = (props: ScriptBlockProps) => {
         </div>
       )}
       {isDragOver && isNotShadow && targetBlock && (
-        <ScriptBlock {...props} arg={defaultBlock(targetBlock)} isNotShadow={false} />
+        <ScriptBlock
+          {...props}
+          arg={defaultBlock(targetBlock)}
+          isNotShadow={false}
+          dropOnPrevElement={dropOnNextElement}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
# ⭐️ 概要

<ScriptBlock
  {...props}
  arg={defaultBlock(targetBlock)}
  isNotShadow={false}
  dropOnPrevElement={dropOnNextElement}
/>

## 😎 目的

#33 のコミット忘れを修正するため。

## 💬 関連する Issue

#35 
